### PR TITLE
feat: add postcss-calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If you are developing a project that uses new CSS language features and must wor
 - Optionally enables [postcss-url](https://github.com/postcss/postcss-url) so that `url()` statements are processed
 - Enables [postcss-mixins](https://github.com/postcss/postcss-mixins) so that you can define mixins
 - Enables [postcss-advanced-variables](https://github.com/jonathantneal/postcss-advanced-variables) add support for iterators (@for and @each)and conditionals (@if and @else)
+- Enables [postcss-calc](https://github.com/postcss/postcss-calc) so that `calc()` references are reduced whenever it's possible
 - Enables [postcss-color-function](https://github.com/postcss/postcss-color-function) so that you can use `alpha`, `lightness` and other color utilities
 
 

--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ module.exports = (options = {}) => {
             }),
             // Add support for `alpha()` and other color utilities
             require('postcss-color-function')(),
+            // Lets you reduce calc() references whenever it's possible
+            require('postcss-calc')(),
         ].filter(Boolean),
     };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2393,6 +2393,11 @@
         "postcss": "^7.0.5"
       }
     },
+    "css-unit-converter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+      "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY="
+    },
     "cssdb": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-4.4.0.tgz",
@@ -7176,6 +7181,17 @@
       "requires": {
         "postcss": "^7.0.2",
         "postcss-selector-parser": "^5.0.0"
+      }
+    },
+    "postcss-calc": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
+      "integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
+      "requires": {
+        "css-unit-converter": "^1.1.1",
+        "postcss": "^7.0.5",
+        "postcss-selector-parser": "^5.0.0-rc.4",
+        "postcss-value-parser": "^3.3.1"
       }
     },
     "postcss-color-function": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "browserslist-config-google": "^1.5.0",
     "postcss-color-function": "^4.0.1",
     "postcss-advanced-variables": "^2.3.2",
+    "postcss-calc": "^7.0.1",
     "postcss-css-variables": "^0.13.0",
     "postcss-import": "^12.0.0",
     "postcss-mixins": "^6.2.0",

--- a/test/__snapshots__/functional.spec.js.snap
+++ b/test/__snapshots__/functional.spec.js.snap
@@ -13,7 +13,8 @@ exports[`should generate correct output for fixtures/example.css 1`] = `
     background: url(\\"data:image/png;base64,\\");
     background-image: -webkit-image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);
     background-image: image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);
-    padding: calc(20px * 2);
+    padding: 40px;
+    margin-top: calc(10px + 10vh);
         border-color: blue
 }
 
@@ -24,7 +25,7 @@ exports[`should generate correct output for fixtures/example.css 1`] = `
 
 
     .image {
-    padding: calc(30px * 2)
+    padding: 60px
     }
 }
 
@@ -48,7 +49,7 @@ exports[`should generate correct output for fixtures/example.css 1`] = `
             background: url(\\"data:image/png;base64,\\");
             background-image: -webkit-image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);
             background-image: image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);
-            padding: calc(20px * 2);
+            padding: 40px;
                 border-color: blue
         }
 
@@ -59,7 +60,7 @@ exports[`should generate correct output for fixtures/example.css 1`] = `
 
 
     .image .bar a {
-            padding: calc(30px * 2)
+            padding: 60px
     }
 }
 
@@ -72,7 +73,7 @@ exports[`should generate correct output for fixtures/example.css 1`] = `
             background: url(\\"data:image/png;base64,\\");
             background-image: -webkit-image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);
             background-image: image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);
-            padding: calc(20px * 2);
+            padding: 40px;
                 border-color: blue
         }
 
@@ -83,7 +84,7 @@ exports[`should generate correct output for fixtures/example.css 1`] = `
 
 
     .image .bar .link {
-            padding: calc(30px * 2)
+            padding: 60px
     }
 }
 
@@ -96,7 +97,7 @@ exports[`should generate correct output for fixtures/example.css 1`] = `
                 background: url(\\"data:image/png;base64,\\");
                 background-image: -webkit-image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);
                 background-image: image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);
-                padding: calc(20px * 2);
+                padding: 40px;
                     border-color: blue
             }
 
@@ -107,7 +108,7 @@ exports[`should generate correct output for fixtures/example.css 1`] = `
 
 
     .image .bar a:hover {
-                padding: calc(30px * 2)
+                padding: 60px
     }
 }
 
@@ -120,7 +121,7 @@ exports[`should generate correct output for fixtures/example.css 1`] = `
                 background: url(\\"data:image/png;base64,\\");
                 background-image: -webkit-image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);
                 background-image: image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);
-                padding: calc(20px * 2);
+                padding: 40px;
                     border-color: blue
             }
 
@@ -131,7 +132,7 @@ exports[`should generate correct output for fixtures/example.css 1`] = `
 
 
     .image .bar .link:hover {
-                padding: calc(30px * 2)
+                padding: 60px
     }
 }
 

--- a/test/__snapshots__/unit.spec.js.snap
+++ b/test/__snapshots__/unit.spec.js.snap
@@ -12,7 +12,12 @@ Object {
         "url": "rebase",
       },
     ],
-    [Function],
+    Array [
+      "postcss-mixins",
+      Object {
+        "mixinsDir": "./src/styles/mixins",
+      },
+    ],
     Array [
       "postcss-advanced-variables",
       Object {
@@ -44,6 +49,9 @@ Object {
     Array [
       "postcss-color-function",
     ],
+    Array [
+      "postcss-calc",
+    ],
   ],
 }
 `;
@@ -54,7 +62,12 @@ Object {
     Array [
       "postcss-import",
     ],
-    [Function],
+    Array [
+      "postcss-mixins",
+      Object {
+        "mixinsDir": "./src/styles/mixins",
+      },
+    ],
     Array [
       "postcss-advanced-variables",
       Object {
@@ -87,6 +100,9 @@ Object {
     ],
     Array [
       "postcss-color-function",
+    ],
+    Array [
+      "postcss-calc",
     ],
   ],
 }
@@ -104,7 +120,12 @@ Object {
         "url": "rebase",
       },
     ],
-    [Function],
+    Array [
+      "postcss-mixins",
+      Object {
+        "mixinsDir": "./src/styles/mixins",
+      },
+    ],
     Array [
       "postcss-advanced-variables",
       Object {
@@ -138,6 +159,9 @@ Object {
     Array [
       "postcss-color-function",
     ],
+    Array [
+      "postcss-calc",
+    ],
   ],
 }
 `;
@@ -154,7 +178,12 @@ Object {
         "url": "rebase",
       },
     ],
-    [Function],
+    Array [
+      "postcss-mixins",
+      Object {
+        "mixinsDir": "./src/styles/mixins",
+      },
+    ],
     Array [
       "postcss-advanced-variables",
       "foo",
@@ -186,6 +215,9 @@ Object {
     Array [
       "postcss-color-function",
     ],
+    Array [
+      "postcss-calc",
+    ],
   ],
 }
 `;
@@ -202,7 +234,12 @@ Object {
         "url": "rebase",
       },
     ],
-    [Function],
+    Array [
+      "postcss-mixins",
+      Object {
+        "mixinsDir": "./src/styles/mixins",
+      },
+    ],
     Array [
       "postcss-advanced-variables",
       Object {
@@ -232,6 +269,9 @@ Object {
     Array [
       "postcss-color-function",
     ],
+    Array [
+      "postcss-calc",
+    ],
   ],
 }
 `;
@@ -248,7 +288,12 @@ Object {
         "url": "rebase",
       },
     ],
-    [Function],
+    Array [
+      "postcss-mixins",
+      Object {
+        "mixinsDir": "./src/styles/mixins",
+      },
+    ],
     Array [
       "postcss-advanced-variables",
       Object {
@@ -281,6 +326,9 @@ Object {
     ],
     Array [
       "postcss-color-function",
+    ],
+    Array [
+      "postcss-calc",
     ],
   ],
 }
@@ -299,7 +347,12 @@ Object {
         "url": "rebase",
       },
     ],
-    [Function],
+    Array [
+      "postcss-mixins",
+      Object {
+        "mixinsDir": "./src/styles/mixins",
+      },
+    ],
     Array [
       "postcss-advanced-variables",
       Object {
@@ -332,6 +385,9 @@ Object {
     ],
     Array [
       "postcss-color-function",
+    ],
+    Array [
+      "postcss-calc",
     ],
   ],
 }
@@ -349,7 +405,10 @@ Object {
         "url": "rebase",
       },
     ],
-    [Function],
+    Array [
+      "postcss-mixins",
+      "foo",
+    ],
     Array [
       "postcss-advanced-variables",
       Object {
@@ -382,6 +441,9 @@ Object {
     ],
     Array [
       "postcss-color-function",
+    ],
+    Array [
+      "postcss-calc",
     ],
   ],
 }
@@ -399,7 +461,12 @@ Object {
         "foo": "bar",
       },
     ],
-    [Function],
+    Array [
+      "postcss-mixins",
+      Object {
+        "mixinsDir": "./src/styles/mixins",
+      },
+    ],
     Array [
       "postcss-advanced-variables",
       Object {
@@ -432,6 +499,9 @@ Object {
     ],
     Array [
       "postcss-color-function",
+    ],
+    Array [
+      "postcss-calc",
     ],
   ],
 }

--- a/test/fixtures/example.css
+++ b/test/fixtures/example.css
@@ -1,6 +1,7 @@
 :root {
     --color-red: red;
     --padding: 20px;
+    --margin-top: 10px;
     --image-url: url("image.png");
     --color-white: #000;
 };
@@ -49,6 +50,7 @@
     background: url("image.png");
     background-image: image-set(url("image.png") 1x, url("image.png") 2x);
     padding: calc(var(--padding) * 2);
+    margin-top: calc(var(--margin-top) + 10vh);
 
     @if 3 < 5 {
         border-color: blue;

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -5,6 +5,8 @@ const preset = require('..');
 jest.mock('postcss-import', () => (options) => ['postcss-import', options].filter((val) => val));
 jest.mock('postcss-url', () => (options) => ['postcss-url', options].filter((val) => val));
 jest.mock('postcss-advanced-variables', () => (options) => ['postcss-advanced-variables', options].filter((val) => val));
+jest.mock('postcss-mixins', () => (options) => ['postcss-mixins', options].filter((val) => val));
+jest.mock('postcss-calc', () => (options) => ['postcss-calc', options].filter((val) => val));
 jest.mock('postcss-preset-env', () => (options) => ['postcss-preset-env', options].filter((val) => val));
 jest.mock('postcss-color-function', () => (options) => ['postcss-color-function', options].filter((val) => val));
 


### PR DESCRIPTION
Use postcss-calc to lets you reduce calc() references whenever it's possible.
When multiple units are mixed together in the same expression, the calc() statement is left as is.