### PR TITLE
feat: add postcss-advanced-variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you are developing a project that uses new CSS language features and must wor
 - Enables [postcss-import](https://github.com/postcss/postcss-import) so that `@import` statements are inlined
 - Optionally enables [postcss-url](https://github.com/postcss/postcss-url) so that `url()` statements are processed
 - Enables [postcss-mixins](https://github.com/postcss/postcss-mixins) so that you can define mixins
-- Enables [postcss-conditionals](https://github.com/andyjansson/postcss-conditionals) so that you can use `@if` and `@else` statements, useful inside mixins
+- Enables [postcss-advanced-variables](https://github.com/jonathantneal/postcss-advanced-variables) add support for iterators (@for and @each)and conditionals (@if and @else)
 - Enables [postcss-color-function](https://github.com/postcss/postcss-color-function) so that you can use `alpha`, `lightness` and other color utilities
 
 
@@ -51,6 +51,7 @@ module.exports = require('postcss-preset-moxy')();
 module.exports = require('postcss-preset-moxy')({
     import: { path: './src/styles' },
     mixins: { mixinsDir: './src/styles/mixins' },
+    advancedVariables: { unresolved: 'warn' },
 });
 ```
 
@@ -60,6 +61,7 @@ Available options:
 | ------ | ------------- | -------- | ------- |
 | import | Options to pass to [postcss-import](https://github.com/postcss/postcss-import#path) | Object | undefined |
 | mixins | Options to pass to [postcss-mixins](https://github.com/postcss/postcss-mixins#mixinsdir) | Object | undefined |
+| advancedVariables | Options to pass to [postcss-advanced-variables](https://github.com/jonathantneal/postcss-advanced-variables#options) | Object | undefined |
 | cssVariables | Options to pass to [postcss-css-variables](https://github.com/MadLittleMods/postcss-css-variables), false disables the plugin | Object/boolean | `{ preserveAtRulesOrder: true }` |
 | url | Options to pass to [postcss-url](https://github.com/postcss/postcss-url), false disables any transpilation of `url()` declarations | Array/Object/boolean | `{ url: 'rebase' }` |
 | browsers | Supported browsers list to pass to [postcss-cssnext](https://github.com/MoOx/postcss-cssnext) | Array | [browserslist-config-google](https://github.com/awkaiser/browserslist-config-google) |

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 'use strict';
 
-module.exports = (options) => {
+module.exports = (options = {}) => {
     options = {
         import: undefined,
-        mixins: undefined,
+        mixins: { mixinsDir: './src/styles/mixins' },
+        advancedVariables: { ...options.advancedVariables, disable: '@mixin, @include, @content, @import' }, // Ignore @mixin, @include, @content and @import at-rules
         browsers: ['extends browserslist-config-google'],
         cssVariables: { preserveAtRulesOrder: true },
         url: { url: 'rebase' },
@@ -18,8 +19,8 @@ module.exports = (options) => {
             options.url && require('postcss-url')(options.url),
             // Add support for CSS mixins
             require('postcss-mixins')(options.mixins),
-            // Add support for @if and @else statements
-            require('postcss-conditionals')(),
+            // Add support for iterators (@for and @each) and conditionals (@if and @else)
+            require('postcss-advanced-variables')(options.advancedVariables),
             // Use postcss-preset-env to enable plugins to transform official CSS features
             // to be compatible in older browsers
             require('postcss-preset-env')({

--- a/package-lock.json
+++ b/package-lock.json
@@ -438,6 +438,11 @@
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
+    "@csstools/sass-import-resolve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/sass-import-resolve/-/sass-import-resolve-1.0.0.tgz",
+      "integrity": "sha512-pH4KCsbtBLLe7eqUrw8brcuFO8IZlN36JjdKlOublibVdAIPHCzEnpBWOVUXK5sCf+DpBi8ZtuWtjF0srybdeA=="
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -981,7 +986,8 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -2359,22 +2365,6 @@
         "postcss": "^7.0.5"
       }
     },
-    "css-color-converter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/css-color-converter/-/css-color-converter-1.1.0.tgz",
-      "integrity": "sha1-wufZPC6WyK2Msax6Hy5J2AUq3jY=",
-      "requires": {
-        "color-convert": "^0.5.2",
-        "color-name": "^1.0.0"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
-        }
-      }
-    },
     "css-color-function": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/css-color-function/-/css-color-function-1.3.3.tgz",
@@ -2402,11 +2392,6 @@
       "requires": {
         "postcss": "^7.0.5"
       }
-    },
-    "css-unit-converter": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
-      "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY="
     },
     "cssdb": {
       "version": "4.4.0",
@@ -4588,6 +4573,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -5712,11 +5698,6 @@
           }
         }
       }
-    },
-    "js-base64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -7167,6 +7148,27 @@
         }
       }
     },
+    "postcss-advanced-variables": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/postcss-advanced-variables/-/postcss-advanced-variables-2.3.3.tgz",
+      "integrity": "sha512-X7nwaP4yDVu3ZWsftQVuVcd/+thKsXTeQ2zQL9ivtgdpXu/ERlSGiOA8D7O/b0jnYj6oO4WpfvOCw7cOnGYEow==",
+      "requires": {
+        "@csstools/sass-import-resolve": "^1",
+        "postcss": "^6"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        }
+      }
+    },
     "postcss-attribute-case-insensitive": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.1.tgz",
@@ -7244,71 +7246,6 @@
       "requires": {
         "postcss": "^7.0.2",
         "postcss-values-parser": "^2.0.0"
-      }
-    },
-    "postcss-conditionals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-conditionals/-/postcss-conditionals-2.1.0.tgz",
-      "integrity": "sha1-TR9iqlQEWM56t3n3FlaQHI+Okpo=",
-      "requires": {
-        "css-color-converter": "^1.0.2",
-        "css-unit-converter": "^1.0.0",
-        "postcss": "^5.0.4"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-            }
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-        },
-        "postcss": {
-          "version": "5.2.18",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-          "requires": {
-            "chalk": "^1.1.3",
-            "js-base64": "^2.1.9",
-            "source-map": "^0.5.6",
-            "supports-color": "^3.2.3"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        }
       }
     },
     "postcss-css-variables": {
@@ -7454,6 +7391,26 @@
       "requires": {
         "camelcase-css": "^2.0.1",
         "postcss": "^7.0.18"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "7.0.18",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
+          "integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "postcss-lab-function": {
@@ -8679,6 +8636,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "browserslist-config-google": "^1.5.0",
     "postcss-color-function": "^4.0.1",
-    "postcss-conditionals": "^2.1.0",
+    "postcss-advanced-variables": "^2.3.2",
     "postcss-css-variables": "^0.13.0",
     "postcss-import": "^12.0.0",
     "postcss-mixins": "^6.2.0",

--- a/test/__snapshots__/functional.spec.js.snap
+++ b/test/__snapshots__/functional.spec.js.snap
@@ -2,9 +2,13 @@
 
 exports[`should generate correct output for fixtures/example.css 1`] = `
 ".image {
+    position: absolute;
+        top: 20px;
+        right: 10px;
+    font-family: Verdana;
+
     -webkit-transition: all 0.2s ease;
     transition: all 0.2s ease;
-    font-family: Verdana;
     color: red;
     background: url(\\"data:image/png;base64,\\");
     background-image: -webkit-image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);
@@ -26,8 +30,20 @@ exports[`should generate correct output for fixtures/example.css 1`] = `
 
 
 
+@media (min-width: 60px) {
+
+
+
+    .image {
+        top: 30px
+    }
+}
+
+
+
 .image .bar a {
             font-family: Verdana;
+
             color: red;
             background: url(\\"data:image/png;base64,\\");
             background-image: -webkit-image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);
@@ -51,6 +67,7 @@ exports[`should generate correct output for fixtures/example.css 1`] = `
 
 .image .bar .link {
             font-family: Verdana;
+
             color: red;
             background: url(\\"data:image/png;base64,\\");
             background-image: -webkit-image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);
@@ -74,6 +91,7 @@ exports[`should generate correct output for fixtures/example.css 1`] = `
 
 .image .bar a:hover {
                 font-family: Verdana;
+
                 color: red;
                 background: url(\\"data:image/png;base64,\\");
                 background-image: -webkit-image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);
@@ -97,6 +115,7 @@ exports[`should generate correct output for fixtures/example.css 1`] = `
 
 .image .bar .link:hover {
                 font-family: Verdana;
+
                 color: red;
                 background: url(\\"data:image/png;base64,\\");
                 background-image: -webkit-image-set(url(\\"data:image/png;base64,\\") 1x, url(\\"data:image/png;base64,\\") 2x);

--- a/test/__snapshots__/unit.spec.js.snap
+++ b/test/__snapshots__/unit.spec.js.snap
@@ -12,11 +12,12 @@ Object {
         "url": "rebase",
       },
     ],
+    [Function],
     Array [
-      "postcss-mixins",
-    ],
-    Array [
-      "postcss-conditionals",
+      "postcss-advanced-variables",
+      Object {
+        "disable": "@mixin, @include, @content, @import",
+      },
     ],
     Array [
       "postcss-preset-env",
@@ -53,11 +54,12 @@ Object {
     Array [
       "postcss-import",
     ],
+    [Function],
     Array [
-      "postcss-mixins",
-    ],
-    Array [
-      "postcss-conditionals",
+      "postcss-advanced-variables",
+      Object {
+        "disable": "@mixin, @include, @content, @import",
+      },
     ],
     Array [
       "postcss-preset-env",
@@ -102,11 +104,60 @@ Object {
         "url": "rebase",
       },
     ],
+    [Function],
     Array [
-      "postcss-mixins",
+      "postcss-advanced-variables",
+      Object {
+        "disable": "@mixin, @include, @content, @import",
+      },
     ],
     Array [
-      "postcss-conditionals",
+      "postcss-preset-env",
+      Object {
+        "autoprefixer": Object {
+          "overrideBrowserslist": Array [
+            "extends browserslist-config-google",
+          ],
+          "remove": false,
+        },
+        "browsers": Array [
+          "extends browserslist-config-google",
+        ],
+        "features": Object {
+          "custom-media-queries": true,
+          "custom-properties": false,
+          "nesting-rules": true,
+        },
+        "insertAfter": Object {
+          "nesting-rules": [Function],
+        },
+        "preserve": false,
+        "stage": 3,
+      },
+    ],
+    Array [
+      "postcss-color-function",
+    ],
+  ],
+}
+`;
+
+exports[`should pass options.advancedVariables to postcss-advanced-variables  1`] = `
+Object {
+  "plugins": Array [
+    Array [
+      "postcss-import",
+    ],
+    Array [
+      "postcss-url",
+      Object {
+        "url": "rebase",
+      },
+    ],
+    [Function],
+    Array [
+      "postcss-advanced-variables",
+      "foo",
     ],
     Array [
       "postcss-preset-env",
@@ -151,11 +202,12 @@ Object {
         "url": "rebase",
       },
     ],
+    [Function],
     Array [
-      "postcss-mixins",
-    ],
-    Array [
-      "postcss-conditionals",
+      "postcss-advanced-variables",
+      Object {
+        "disable": "@mixin, @include, @content, @import",
+      },
     ],
     Array [
       "postcss-preset-env",
@@ -196,11 +248,12 @@ Object {
         "url": "rebase",
       },
     ],
+    [Function],
     Array [
-      "postcss-mixins",
-    ],
-    Array [
-      "postcss-conditionals",
+      "postcss-advanced-variables",
+      Object {
+        "disable": "@mixin, @include, @content, @import",
+      },
     ],
     Array [
       "postcss-preset-env",
@@ -246,11 +299,12 @@ Object {
         "url": "rebase",
       },
     ],
+    [Function],
     Array [
-      "postcss-mixins",
-    ],
-    Array [
-      "postcss-conditionals",
+      "postcss-advanced-variables",
+      Object {
+        "disable": "@mixin, @include, @content, @import",
+      },
     ],
     Array [
       "postcss-preset-env",
@@ -295,12 +349,12 @@ Object {
         "url": "rebase",
       },
     ],
+    [Function],
     Array [
-      "postcss-mixins",
-      "foo",
-    ],
-    Array [
-      "postcss-conditionals",
+      "postcss-advanced-variables",
+      Object {
+        "disable": "@mixin, @include, @content, @import",
+      },
     ],
     Array [
       "postcss-preset-env",
@@ -345,11 +399,12 @@ Object {
         "foo": "bar",
       },
     ],
+    [Function],
     Array [
-      "postcss-mixins",
-    ],
-    Array [
-      "postcss-conditionals",
+      "postcss-advanced-variables",
+      Object {
+        "disable": "@mixin, @include, @content, @import",
+      },
     ],
     Array [
       "postcss-preset-env",

--- a/test/fixtures/example.css
+++ b/test/fixtures/example.css
@@ -18,10 +18,33 @@
     font-family: Verdana;
 }
 
+@define-mixin position $type: absolute, $top: null, $right: null, $bottom: null, $left: null {
+    position: $type;
+
+    @if $top != null {
+        top: $top;
+    }
+
+    @if $right != null {
+        right: $right;
+    }
+
+    @if $bottom != null {
+        bottom: $bottom;
+    }
+
+    @if $left != null {
+        left: $left;
+    }
+}
+
+
 .image {
+    @mixin position absolute, var(--padding), 10px, null, null;
+    @mixin font-default;
+
     -webkit-transition: all 0.2s ease;
     transition: all 0.2s ease;
-    @mixin font-default;
     color: var(--color-red);
     background: url("image.png");
     background-image: image-set(url("image.png") 1x, url("image.png") 2x);
@@ -35,6 +58,7 @@
         & a,
         & .link {
             @mixin font-default;
+
             color: var(--color-red);
             background: var(--image-url);
             background-image: image-set(url("image.png") 1x, var(--image-url) 2x);
@@ -47,6 +71,7 @@
 
             &:hover {
                 @mixin font-default;
+
                 color: var(--color-red);
                 background: url("image.png");
                 background-image: image-set(url("image.png") 1x, url("image.png") 2x);

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -4,8 +4,7 @@ const preset = require('..');
 
 jest.mock('postcss-import', () => (options) => ['postcss-import', options].filter((val) => val));
 jest.mock('postcss-url', () => (options) => ['postcss-url', options].filter((val) => val));
-jest.mock('postcss-mixins', () => (options) => ['postcss-mixins', options].filter((val) => val));
-jest.mock('postcss-conditionals', () => (options) => ['postcss-conditionals', options].filter((val) => val));
+jest.mock('postcss-advanced-variables', () => (options) => ['postcss-advanced-variables', options].filter((val) => val));
 jest.mock('postcss-preset-env', () => (options) => ['postcss-preset-env', options].filter((val) => val));
 jest.mock('postcss-color-function', () => (options) => ['postcss-color-function', options].filter((val) => val));
 
@@ -21,6 +20,10 @@ it('should pass options.import to postcss-import ', () => {
 
 it('should pass options.mixins to postcss-mixins ', () => {
     expect(preset({ mixins: 'foo' })).toMatchSnapshot();
+});
+
+it('should pass options.advancedVariables to postcss-advanced-variables ', () => {
+    expect(preset({ advancedVariables: 'foo' })).toMatchSnapshot();
 });
 
 it('should disable postcss-url if options.url is false', () => {


### PR DESCRIPTION
Add support for:
- conditionals (@if and @else),
- iterators (@for and @each),
- ~mixins(@mixin, @include, and @content rules)~

with this plugin we don't need anymore `postcss-conditionals`, ~and `postcss-mixins`~

this commit fixes #33